### PR TITLE
workflows/pages: add firmware downloads site and manifest pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.repository == 'loongson/Firmware'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Generate manifest
+        run: python3 scripts/generate-manifest.py
+
+      - name: Stage web assets
+        run: cp manifest.json web/manifest.json
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Firmware  
-[简体中文](https://github.com/loongson/Firmware/blob/main/README_CN.md)
-### Firmware Of LoongArch Machines  
+# Firmware
 
-LoongArch machines firmware binary repository, where you can find firmware for almost machine types, including Qemu binaries. It will become more and more complete.  
-The firewares are all based UDK2018, the boot logo is Loongson logo, EDKII style setup UI, **adapt upstream linux kernel, support EfiStub**.   
+[![简体中文](https://img.shields.io/badge/lang-中文-red.svg)](README_CN.md)
 
-### <font color=red>Notice</font>  
+### Downloads Hub
+For your convenience, GitHub Pages hosts a downloads index to make web searching for specific model/version firmware easier.
+- 👉 [https://loongson.github.io/Firmware/](https://loongson.github.io/Firmware/)
+The page is deployed automatically on pushes to `main` via GitHub Actions.
+
+### Firmware Of LoongArch Machines
+LoongArch machines firmware binary repository, where you can find firmware for almost machine types, including Qemu binaries. It will become more and more complete.
+The firewares are all based EDK2, the boot logo is Loongson logo, EDKII style setup UI, **adapt upstream linux kernel, support EfiStub**.
+
+### <font color=red>Notice</font>
 <font color=red>**There firmwares have not yet adapted to the UOS and Kylin OS current versions, we only recommend developer. Unless you are a developer or familiar for LoongArch, do not try update the firmware easily.** </font>
 
 ### Prepare to update  

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,11 +1,15 @@
-# 固件  
+# 固件
 
-### LoongArch平台固件    
+### 下载页面
+为了方便开发者，我们在 GitHub Pages 提供了下载索引页，方便通过机型/版本关键词进行 Web 搜索定位固件。
+- 👉 [https://loongson.github.io/Firmware/](https://loongson.github.io/Firmware/)
+该页面会在 `main` 分支有更新时由 GitHub Actions 自动部署。
 
-LoongArch平台固件二进制仓库，在这里可以找到尽可能多的主机类型，包括虚拟机二进制。我们会越来越完善该仓库。  
-所有固件均基于UDK2018版本，启动logo为龙芯logo，EDKII风格setup UI，**适配上游linux内核，支持EfiStub启动**  
+### LoongArch平台固件
+LoongArch平台固件二进制仓库，在这里可以找到尽可能多的主机类型，包括虚拟机二进制。我们会越来越完善该仓库。
+所有固件均基于EDK2版本，启动logo为龙芯logo，EDKII风格setup UI，**适配上游linux内核，支持EfiStub启动**
 
-### <font color=red>注意</font>  
+### <font color=red>注意</font>
 <font color=red>**本仓库固件暂时不适用现有版本UOS和麒麟OS系统，我们只推荐开发者或者对LoongArch架构非常熟悉的人员更新固件，否则不要轻易尝试。**</font>  
 
 ### Prepare to update  

--- a/scripts/generate-manifest.py
+++ b/scripts/generate-manifest.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+import json
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+ROOT = Path(__file__).resolve().parents[1]
+
+LINE_RE = re.compile(r'^([0-9a-fA-F]{64})\s+\*?(\S+)$')
+VERSION_RE = re.compile(r'V\d+(?:\.\d+)+')
+BASE_RE = re.compile(r'^(UDK\d+|EDK\d+)', re.IGNORECASE)
+BOARD_REV_RE = re.compile(r'V\d+\.(?:\d+|x)(?=$|[_-])', re.IGNORECASE)
+BRACKET_RE = re.compile(r'\[([^\]]+)\]')
+STAGE_TOKEN_RE = re.compile(r'^(beta\d+[a-z0-9]*|prestable\d+[a-z0-9]*|stable\d+[a-z0-9]*|rc\d+[a-z0-9]*)$',
+                            re.IGNORECASE)
+
+
+def get_git_timestamp(path: Path, cache: dict) -> Optional[int]:
+    """Return last commit timestamp (unix seconds) for a file path."""
+    key = str(path)
+    if key in cache:
+        return cache[key]
+    rel = path.relative_to(ROOT)
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct", "--", str(rel)],
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True,
+            check=False,
+        )
+        out = result.stdout.strip()
+        ts = int(out) if out.isdigit() else None
+    except Exception:
+        ts = None
+    cache[key] = ts
+    return ts
+
+
+def parse_base(filename: str) -> Optional[str]:
+    match = BASE_RE.match(filename)
+    if match:
+        return match.group(1).upper()
+    token = filename.split('_')[0].split('-')[0]
+    return token.upper() if token else None
+
+
+def parse_versions(filename: str) -> List[str]:
+    return VERSION_RE.findall(filename) or []
+
+
+def parse_board_rev(filename: str, base: Optional[str] = None) -> Optional[str]:
+    """Parse mainboard revision (e.g. V1.0, V0.x) from the board identifier part.
+
+    This is *not* the firmware/RefCode version (e.g. V5.0.0344). We intentionally only
+    match patterns like V<major>.<minor|x> that end before a third dot.
+    """
+    name = re.sub(r"\.(fd|bin|zip)$", "", filename, flags=re.IGNORECASE)
+    if base and name.upper().startswith(base.upper()):
+        name = name[len(base):].lstrip("_-")
+    m = BOARD_REV_RE.search(name)
+    return m.group(0) if m else None
+
+
+def parse_build(filename: str) -> Optional[str]:
+    lower = filename.lower()
+    if "dbg" in lower or "debug" in lower:
+        return "dbg"
+    if "rel" in lower or "release" in lower:
+        return "rel"
+    return None
+
+
+def derive_firmware_type(base: Optional[str]) -> Optional[str]:
+    if not base:
+        return None
+    if base.upper().startswith("EDK"):
+        return "UEFI"
+    return base.upper()
+
+
+def strip_platform_prefix(text: str) -> str:
+    if not text:
+        return text
+    return re.sub(r'^(loongarch64|loongarch|loongson)[_-]+', '', text, flags=re.IGNORECASE)
+
+
+def parse_stage_from_filename(filename: str, base: Optional[str] = None) -> Optional[str]:
+    name = re.sub(r"\.(fd|bin|zip)$", "", filename, flags=re.IGNORECASE)
+    if base and name.upper().startswith(base.upper()):
+        name = name[len(base):].lstrip("_-")
+    name = BRACKET_RE.sub("", name).strip("_-")
+    name = re.sub(r"(_|-)?(dbg|debug|rel|release)$", "", name, flags=re.IGNORECASE).strip("_-")
+    tokens = [t for t in re.split(r"[_-]+", name) if t]
+    for token in reversed(tokens):
+        if STAGE_TOKEN_RE.match(token):
+            return token
+    return None
+
+
+def parse_board_id_and_special(filename: str, base: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Extract board identifier and optional special tag.
+
+    Naming rule (from spec):
+      固件类型_主板标识_[特殊标识]_版本号_产品阶段/版本代号
+    """
+    name = re.sub(r"\.(fd|bin|zip)$", "", filename, flags=re.IGNORECASE)
+
+    if base and name.upper().startswith(base.upper()):
+        name = name[len(base):].lstrip("_-")
+    mv = VERSION_RE.search(name)
+    mid = name[:mv.start()] if mv else name
+
+    special = None
+    bm = BRACKET_RE.search(mid)
+    if bm:
+        special = bm.group(1)
+        mid = BRACKET_RE.sub("", mid)
+        mid = re.sub(r"__+", "_", mid).strip("_-")
+    if not mv:
+        mid = re.sub(r"(_|-)?(dbg|debug|rel|release)$", "", mid, flags=re.IGNORECASE).strip("_-")
+        tokens = [t for t in re.split(r"[_-]+", mid) if t]
+        if tokens and STAGE_TOKEN_RE.match(tokens[-1]):
+            mid = "-".join(tokens[:-1]).strip("_-")
+    board_id = strip_platform_prefix(mid.strip("_-")) or None
+    return board_id, special
+
+
+def parse_fw_version_and_stage(refcode_base: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Split RefCode base into firmware version + stage/variant."""
+    if not refcode_base:
+        return None, None
+    base = refcode_base.strip("_-")
+    mv = VERSION_RE.search(base)
+    if not mv:
+        return None, base or None
+    version = mv.group(0)
+    rest = (base[mv.end():] or "").strip("_-")
+    stage = rest or None
+    return version, stage
+
+
+def normalize_stage(stage: Optional[str]) -> Optional[str]:
+    if not stage:
+        return None
+    s = stage.strip("_-")
+    m = re.match(r"^(stable)(\d{6})$", s, flags=re.IGNORECASE)
+    if m:
+        # stableYYYYMM -> stableYYMM
+        return f"{m.group(1)}{m.group(2)[-4:]}"
+    return s
+
+def normalize_fw_version(ver: Optional[str]) -> Optional[str]:
+    if not ver:
+        return None
+    v = ver.strip()
+    # If already has 4 numeric components like V5.0.0.343, keep as-is.
+    if re.match(r"^V\d+\.\d+\.\d+\.\d+$", v, flags=re.IGNORECASE):
+        return v
+    m = re.match(r"^V(\d+)\.(\d+)\.(\d+)$", v, flags=re.IGNORECASE)
+    if not m:
+        return v
+    a, b, c = m.group(1), m.group(2), m.group(3)
+    # If last component is 4 digits (e.g. 0343), split to 0.343
+    if len(c) == 4 and c.isdigit():
+        return f"V{a}.{b}.{c[0]}.{c[1:]}"
+    return v
+
+def make_version_full(fw_version: Optional[str], stage: Optional[str]) -> Optional[str]:
+    v = normalize_fw_version(fw_version)
+    s = normalize_stage(stage)
+    if v and s:
+        return f"{v}_{s}"
+    return v or s
+
+def parse_refcode_base(filename: str, board_rev: Optional[str], base: Optional[str] = None) -> Optional[str]:
+    """RefCode Base / UEFI base version string."""
+    name = re.sub(r"\.(fd|bin|zip)$", "", filename, flags=re.IGNORECASE)
+
+    if base and name.upper().startswith(base.upper()):
+        name = name[len(base):].lstrip("_-")
+    cut_idx = None
+    if board_rev:
+        i = name.find(board_rev)
+        if i != -1:
+            cut_idx = i + len(board_rev)
+    if cut_idx is None:
+        j = name.find('_')
+        cut_idx = j + 1 if j != -1 else 0
+
+    tail = name[cut_idx:].strip("_-")
+    tail = BRACKET_RE.sub("", tail).strip("_-")
+    tail = re.sub(r"(_|-)?(dbg|debug|rel|release)$", "", tail, flags=re.IGNORECASE).strip("_-")
+    if not VERSION_RE.search(tail):
+        return None
+    return tail or None
+
+
+def parse_date_key(text: str) -> Optional[Tuple[int, int, int]]:
+    match = re.search(r"(20\d{6})", text)
+    if match:
+        val = match.group(1)
+        return (int(val[0:4]), int(val[4:6]), int(val[6:8]))
+    match = re.search(r"(20\d{4})", text)
+    if match:
+        val = match.group(1)
+        return (int(val[0:4]), int(val[4:6]), 0)
+    match = re.search(r"(\d{2})(\d{2})[_-]?(\d{2})(\d{2})", text)
+    if match:
+        yy, mm, dd1, dd2 = match.groups()
+        day = int(dd1 + dd2)
+        return (2000 + int(yy), int(mm), day)
+    match = re.search(r"(?<!\d)(\d{2})(\d{2})(?!\d)", text)
+    if match:
+        yy, mm = match.groups()
+        return (2000 + int(yy), int(mm), 0)
+    return None
+
+
+def version_key(version: Optional[str]) -> Tuple[int, ...]:
+    if not version:
+        return ()
+    nums = re.findall(r"\d+", version)
+    return tuple(int(n) for n in nums)
+
+
+def sort_key(artifact: dict) -> tuple:
+    # Prefer filesystem timestamp if available, else fall back to date-like tokens in refcode/path.
+    ts = artifact.get("timestamp") or 0
+    text = f"{artifact.get('refcode_base') or ''} {artifact.get('path') or ''}"
+    date_key = parse_date_key(text) or (0, 0, 0)
+    return (ts, date_key, version_key(artifact.get("refcode_base")), artifact.get("edk") or "", artifact.get("build") or "")
+
+
+def main() -> None:
+    sha_files = sorted(ROOT.rglob("SHA256SUMS.txt"))
+    machines = []
+    git_ts_cache = {}
+
+    for sha_path in sha_files:
+        rel_dir = sha_path.parent.relative_to(ROOT)
+        parts = rel_dir.parts
+
+        collection = None
+        series = None
+        category = None
+        model = None
+
+        if len(parts) >= 1 and parts[0] == "MultiArchUefiSupport":
+            collection = parts[0]
+            if len(parts) >= 2:
+                series = parts[1]
+            if len(parts) >= 3:
+                category = parts[2]
+            if len(parts) >= 4:
+                model = parts[3]
+        elif len(parts) >= 3 and parts[0].endswith("Series"):
+            series = parts[0]
+            category = parts[1]
+            model = parts[2]
+        else:
+            model = parts[-1] if parts else str(rel_dir)
+
+        artifacts = []
+        with sha_path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                match = LINE_RE.match(line)
+                if not match:
+                    continue
+                sha256, filename = match.groups()
+                artifact_path = str(rel_dir / filename)
+
+                edk = parse_base(filename)
+                firmware_type = derive_firmware_type(edk)
+                board_rev = parse_board_rev(filename, edk)
+                refcode_base = parse_refcode_base(filename, board_rev, edk)
+                build = parse_build(filename)
+                board_id, special_tag = parse_board_id_and_special(filename, edk)
+                fw_version, stage = parse_fw_version_and_stage(refcode_base)
+                if not stage:
+                    stage = parse_stage_from_filename(filename, edk)
+
+                # File mtime (best-effort) for sorting
+                file_path = (ROOT / rel_dir / filename)
+                try:
+                    ts = int(file_path.stat().st_mtime)
+                    dt = datetime.fromtimestamp(ts).isoformat(timespec='seconds')
+                except Exception:
+                    ts = 0
+                    dt = None
+
+                git_ts = get_git_timestamp(file_path, git_ts_cache)
+                git_dt = datetime.fromtimestamp(git_ts).isoformat(timespec='seconds') if git_ts else None
+
+                artifacts.append(
+                    {
+                        # New semantic fields (schema v2)
+                        "edk": edk,
+                        "edk2_baseline": edk,
+                        "firmware_type": firmware_type,
+                        "version_full": make_version_full(fw_version, stage),
+                        "board_rev": board_rev,
+                        "refcode_base": refcode_base,
+                        "build": build,
+                        "board_id": board_id,
+                        "special_tag": special_tag,
+                        "fw_version": fw_version,
+                        "stage": stage,
+                        "timestamp": ts,
+                        "datetime": dt,
+                        "git_timestamp": git_ts or 0,
+                        "git_datetime": git_dt,
+                        # Existing fields kept for backward compatibility
+                        "base": edk,
+                        "version": board_rev,
+                        "release_tag": refcode_base,
+                        "secure_boot": None,
+                        "gmem": None,
+                        "path": artifact_path,
+                        "sha256": sha256.lower(),
+                        "checksum_source": str(sha_path.relative_to(ROOT)),
+                    }
+                )
+
+        latest = []
+        if artifacts:
+            latest_map = {}
+            for artifact in artifacts:
+                key = (artifact.get("edk"), artifact.get("board_rev"), artifact.get("build"))
+                if key not in latest_map or sort_key(artifact) > sort_key(latest_map[key]):
+                    latest_map[key] = artifact
+            latest = list(latest_map.values())
+            latest.sort(key=lambda a: (a.get("edk") or "", a.get("board_rev") or "", a.get("build") or ""))
+
+        machines.append(
+            {
+                "collection": collection,
+                "series": series,
+                "category": category,
+                "model": model,
+                "group_path": str(rel_dir),
+                "latest": latest,
+                "artifacts": artifacts,
+            }
+        )
+
+    manifest = {
+        "schema_version": "2.0",
+        "coverage": "full",
+        "generated_from": "SHA256SUMS.txt",
+        "latest_rule": "date_desc_then_refcode_desc",
+        "machines": machines,
+    }
+
+    out_path = ROOT / "manifest.json"
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+    web_path = ROOT / "web" / "manifest.json"
+    if web_path.parent.exists():
+        with web_path.open("w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, sort_keys=False)
+            f.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,632 @@
+const state = {
+  showAll: false,
+  query: '',
+  manifest: null,
+  lang: 'en',
+  tagType: 'series',
+  tagValue: '',
+  modelValue: '',
+};
+
+// Per-model expand state for artifact lists (keyed by group_path).
+const expandedModels = new Set();
+
+const cardsEl = document.getElementById('cards');
+const metaEl = document.getElementById('meta');
+const searchEl = document.getElementById('search');
+const latestBtn = document.getElementById('latestBtn');
+const allBtn = document.getElementById('allBtn');
+const zhBtn = document.getElementById('zhBtn');
+const enBtn = document.getElementById('enBtn');
+const tagIndexLabelEl = document.getElementById('tagIndexLabel');
+const tagSelectLabelEl = document.getElementById('tagSelectLabel');
+const tagSelectEl = document.getElementById('tagSelect');
+const tagTabs = Array.from(document.querySelectorAll('[data-tag-type]'));
+const modelSelectLabelEl = document.getElementById('modelSelectLabel');
+const modelSelectEl = document.getElementById('modelSelect');
+const eyebrowEl = document.getElementById('eyebrow');
+const heroTitleEl = document.getElementById('heroTitle');
+const subheadEl = document.getElementById('subhead');
+const searchLabelEl = document.getElementById('searchLabel');
+const footerTextEl = document.getElementById('footerText');
+const repoLinkTextEl = document.getElementById('repoLinkText');
+
+const i18n = {
+  en: {
+    eyebrow: 'Loongson Community firmware',
+    heroTitle: 'Downloads Hub',
+    subhead: 'Latest BIOS and firmware artifacts, grouped by device model. Use search or switch to full history when needed.',
+    repoLink: 'GitHub Repo',
+    searchLabel: 'Search',
+    searchPlaceholder: 'Model, series, or path',
+    latest: 'Latest',
+    all: 'All',
+    language: 'Language',
+    indexBy: 'Index by',
+    indexAll: 'All',
+    indexCollection: 'Collection',
+    indexSeries: 'Series',
+    indexCategory: 'Category',
+    indexTags: 'Tags',
+    indexAllTags: 'All tags',
+    indexModels: 'Models',
+    indexAllModels: 'All models',
+    metaSummary: (models, artifacts) => `${models} models, ${artifacts} artifacts`,
+    loading: 'Loading manifest...',
+    loadError: 'Failed to load manifest.json',
+    generatedFrom: 'Generated from',
+    generatedJoin: 'and',
+    firmwareType: 'Firmware Type',
+    edkBaseline: 'EDK2 Baseline',
+    refcodeBaseline: 'RefCode Baseline',
+    boardId: 'Board ID',
+    boardRev: 'Board Rev',
+    version: 'Version',
+    build: 'Build',
+    releaseTime: 'Push Time',
+    download: 'Download',
+    noArtifacts: 'No artifacts found for this model.',
+    expandMore: (count) => `Show more (${count})`,
+    collapse: 'Collapse',
+    na: 'N/A',
+    colon: ': ',
+  },
+  zh: {
+    eyebrow: '龙芯社区固件',
+    heroTitle: '下载中心',
+    subhead: '按机型分组的 BIOS/固件下载列表，可搜索或切换到完整历史。',
+    repoLink: '访问 GitHub 仓库',
+    searchLabel: '搜索',
+    searchPlaceholder: '型号、系列或路径',
+    latest: '最新',
+    all: '全部',
+    language: '语言',
+    indexBy: '索引类型',
+    indexAll: '全部',
+    indexCollection: '集合',
+    indexSeries: '系列',
+    indexCategory: '类别',
+    indexTags: '标签',
+    indexAllTags: '全部标签',
+    indexModels: '型号',
+    indexAllModels: '全部型号',
+    metaSummary: (models, artifacts) => `${models} 个机型，${artifacts} 个固件`,
+    loading: '加载清单中...',
+    loadError: 'manifest.json 加载失败',
+    generatedFrom: '数据来源',
+    generatedJoin: '、',
+    firmwareType: '固件类型',
+    edkBaseline: 'EDK2 基线',
+    refcodeBaseline: 'RefCode 基线',
+    boardId: '主板标识',
+    boardRev: '主板版本',
+    version: '版本号',
+    build: '构建类型',
+    releaseTime: '推送时间',
+    download: '下载',
+    noArtifacts: '该机型暂无固件。',
+    expandMore: (count) => `展开更多（${count}）`,
+    collapse: '收起',
+    na: 'N/A',
+    colon: '：',
+  },
+};
+
+const DEFAULT_VISIBLE = 2;
+const RAW_BASE_URL = 'https://raw.githubusercontent.com/loongson/firmware/main/';
+
+function detectLanguage() {
+  const stored = localStorage.getItem('fw_lang');
+  if (stored && i18n[stored]) return stored;
+  //const browser = (navigator.language || '').toLowerCase();
+  //return browser.startsWith('zh') ? 'zh' : 'en';
+  return 'en';
+}
+
+function applyLanguage(lang) {
+  const locale = i18n[lang] || i18n.en;
+  state.lang = lang;
+  localStorage.setItem('fw_lang', lang);
+
+  if (eyebrowEl) eyebrowEl.textContent = locale.eyebrow;
+  if (heroTitleEl) heroTitleEl.textContent = locale.heroTitle;
+  if (subheadEl) subheadEl.textContent = locale.subhead;
+  if (repoLinkTextEl) repoLinkTextEl.textContent = locale.repoLink;
+  if (searchLabelEl) searchLabelEl.textContent = locale.searchLabel;
+  if (searchEl) searchEl.placeholder = locale.searchPlaceholder;
+  if (footerTextEl) {
+    footerTextEl.innerHTML = `${locale.generatedFrom} <code>manifest.json</code> ${locale.generatedJoin} <code>SHA256SUMS.txt</code>.`;
+  }
+  latestBtn.textContent = locale.latest;
+  allBtn.textContent = locale.all;
+  if (tagIndexLabelEl) tagIndexLabelEl.textContent = locale.indexBy;
+  if (tagSelectLabelEl) tagSelectLabelEl.textContent = locale.indexTags;
+  if (modelSelectLabelEl) modelSelectLabelEl.textContent = locale.indexModels;
+  tagTabs.forEach((tab) => {
+    const type = tab.dataset.tagType;
+    if (type === 'all') tab.textContent = locale.indexAll;
+    if (type === 'collection') tab.textContent = locale.indexCollection;
+    if (type === 'series') tab.textContent = locale.indexSeries;
+    if (type === 'category') tab.textContent = locale.indexCategory;
+  });
+
+  zhBtn.classList.toggle('is-active', lang === 'zh');
+  enBtn.classList.toggle('is-active', lang === 'en');
+
+  if (!state.manifest && metaEl) {
+    metaEl.textContent = locale.loading;
+  }
+  updateTagOptions();
+  updateModelOptions();
+  render();
+}
+
+function normalize(value) {
+  return (value || '').toLowerCase();
+}
+
+function uniqueSorted(values) {
+  const list = Array.from(new Set(values.filter(Boolean)));
+  return list.sort((a, b) => String(a).localeCompare(String(b)));
+}
+
+function buildTagValues(type, machines) {
+  if (!type || type === 'all') return [];
+  const values = machines.map((machine) => machine[type]).filter(Boolean);
+  return uniqueSorted(values);
+}
+
+function updateTagOptions() {
+  if (!tagSelectEl) return;
+  const locale = i18n[state.lang] || i18n.en;
+  const machines = state.manifest?.machines || [];
+  const type = state.tagType || 'all';
+  const values = buildTagValues(type, machines);
+
+  tagSelectEl.innerHTML = '';
+  const allOption = document.createElement('option');
+  allOption.value = '';
+  allOption.textContent = locale.indexAllTags;
+  tagSelectEl.appendChild(allOption);
+
+  values.forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    tagSelectEl.appendChild(option);
+  });
+
+  tagSelectEl.disabled = type === 'all';
+  if (type === 'all') {
+    state.tagValue = '';
+    tagSelectEl.value = '';
+  } else if (state.tagValue && values.includes(state.tagValue)) {
+    tagSelectEl.value = state.tagValue;
+  } else {
+    state.tagValue = '';
+    tagSelectEl.value = '';
+  }
+}
+
+function updateModelOptions() {
+  if (!modelSelectEl) return;
+  const locale = i18n[state.lang] || i18n.en;
+  const machines = state.manifest?.machines || [];
+  const values = uniqueSorted(machines.map((machine) => machine.model || machine.group_path).filter(Boolean));
+
+  modelSelectEl.innerHTML = '';
+  const allOption = document.createElement('option');
+  allOption.value = '';
+  allOption.textContent = locale.indexAllModels;
+  modelSelectEl.appendChild(allOption);
+
+  values.forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    modelSelectEl.appendChild(option);
+  });
+
+  if (state.modelValue && values.includes(state.modelValue)) {
+    modelSelectEl.value = state.modelValue;
+  } else {
+    state.modelValue = '';
+    modelSelectEl.value = '';
+  }
+}
+
+function buildTagList(machine) {
+  const tags = [];
+  if (machine.series) tags.push(machine.series);
+  if (machine.category) tags.push(machine.category);
+  if (machine.collection) tags.push(machine.collection);
+  return tags;
+}
+
+function artifactTitleLine(artifact) {
+  // Display title in a user-facing way:
+  // UEFI / <BoardID> <BoardRev> / <BUILD>
+  const baseline = artifact.edk2_baseline || artifact.edk || artifact.base || null;
+  const fwType = (baseline && /^(EDK|UDK)/i.test(baseline))
+    ? 'UEFI'
+    : (artifact.firmware_type || artifact.fw_type || baseline || null);
+  const boardId = artifact.board_id || artifact.machine || null;
+  const boardRev = artifact.board_rev || artifact.version || null;
+  const build = artifact.build ? artifact.build.toUpperCase() : null;
+
+  const left = [
+    fwType || 'N/A',
+    (boardId ? `${boardId}${boardRev ? ' ' + boardRev : ''}` : 'N/A'),
+  ].join(' / ');
+
+  return build ? `${left} / ${build}` : left;
+}
+
+
+function artifactMetaLines(artifact) {
+  // Key-value rows; missing values show as N/A.
+  const locale = i18n[state.lang] || i18n.en;
+  const baseline = artifact.edk2_baseline || artifact.edk || artifact.base || null;
+  const fwType = (baseline && /^(EDK|UDK)/i.test(baseline))
+    ? 'UEFI'
+    : (artifact.firmware_type || artifact.fw_type || null);
+  const refcode = artifact.refcode_base || artifact.release_tag || null;
+
+  const boardId = artifact.board_id || artifact.machine || null;
+  const boardRev = artifact.board_rev || artifact.version || null;
+
+  // Prefer a fully-formed version string; otherwise compose from parts.
+  const verFull = artifact.version_full
+    || artifact.fw_version_full
+    || (artifact.fw_version && artifact.stage ? `${artifact.fw_version}_${artifact.stage}` : artifact.fw_version)
+    || null;
+
+  const build = artifact.build || null;
+  const releasedRaw = artifact.git_datetime || artifact.datetime || null;
+  const released = releasedRaw ? releasedRaw.replace('T', ' ') : null;
+
+  return [
+    [locale.boardId, boardId],
+    [locale.boardRev, boardRev],
+    [locale.firmwareType, fwType || (baseline && /^(EDK|UDK)/i.test(baseline) ? 'UEFI' : null)],
+    [locale.edkBaseline, baseline],
+    [locale.refcodeBaseline, refcode],
+    [locale.version, verFull],
+    [locale.build, build],
+    [locale.releaseTime, released],
+  ].map(([k, v]) => `${k}${locale.colon}${v || locale.na}`);
+}
+
+function parseDateKey(text) {
+  if (!text) return null;
+  const m1 = text.match(/(20\d{6})/);
+  if (m1) {
+    const val = m1[1];
+    return [Number(val.slice(0, 4)), Number(val.slice(4, 6)), Number(val.slice(6, 8))];
+  }
+  const m2 = text.match(/(20\d{4})/);
+  if (m2) {
+    const val = m2[1];
+    return [Number(val.slice(0, 4)), Number(val.slice(4, 6)), 0];
+  }
+  const m3 = text.match(/(\d{2})(\d{2})[_-]?(\d{2})(\d{2})/);
+  if (m3) {
+    const [, yy, mm, dd1, dd2] = m3;
+    return [2000 + Number(yy), Number(mm), Number(dd1 + dd2)];
+  }
+  const m4 = text.match(/(?<!\d)(\d{2})(\d{2})(?!\d)/);
+  if (m4) {
+    const [, yy, mm] = m4;
+    return [2000 + Number(yy), Number(mm), 0];
+  }
+  return null;
+}
+
+function versionKey(version) {
+  if (!version) return [];
+  return (version.match(/\d+/g) || []).map((n) => Number(n));
+}
+
+function compareNumberArray(a = [], b = []) {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] || 0;
+    const bv = b[i] || 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
+}
+
+function artifactSortKey(artifact) {
+  const ts = artifact?.timestamp || 0;
+  const text = `${artifact?.refcode_base || ''} ${artifact?.path || ''}`;
+  const dateKey = parseDateKey(text) || [0, 0, 0];
+  const verKey = versionKey(artifact?.refcode_base);
+  const edk = artifact?.edk || '';
+  const build = artifact?.build || '';
+  return { ts, dateKey, verKey, edk, build };
+}
+
+function compareArtifactKey(aKey, bKey) {
+  if (aKey.ts !== bKey.ts) return aKey.ts - bKey.ts;
+  const dateCmp = compareNumberArray(aKey.dateKey, bKey.dateKey);
+  if (dateCmp) return dateCmp;
+  const verCmp = compareNumberArray(aKey.verKey, bKey.verKey);
+  if (verCmp) return verCmp;
+  const edkCmp = aKey.edk.localeCompare(bKey.edk);
+  if (edkCmp) return edkCmp;
+  return aKey.build.localeCompare(bKey.build);
+}
+
+function bestArtifactKey(artifacts) {
+  if (!Array.isArray(artifacts) || !artifacts.length) return null;
+  let best = artifactSortKey(artifacts[0]);
+  for (let i = 1; i < artifacts.length; i += 1) {
+    const nextKey = artifactSortKey(artifacts[i]);
+    if (compareArtifactKey(best, nextKey) < 0) {
+      best = nextKey;
+    }
+  }
+  return best;
+}
+
+function updateArtifactList(container, artifacts, key, toggle) {
+  const locale = i18n[state.lang] || i18n.en;
+  const isExpanded = expandedModels.has(key);
+  const visibleCount = isExpanded
+    ? artifacts.length
+    : Math.min(DEFAULT_VISIBLE, artifacts.length);
+
+  container.innerHTML = '';
+
+  for (let i = 0; i < visibleCount; i += 1) {
+    container.appendChild(createArtifactBox(artifacts[i]));
+  }
+
+  if (!artifacts.length) {
+    const empty = document.createElement('div');
+    empty.className = 'artifact';
+    empty.textContent = locale.noArtifacts;
+    container.appendChild(empty);
+  }
+
+  if (toggle) {
+    toggle.textContent = isExpanded
+      ? locale.collapse
+      : locale.expandMore(artifacts.length - DEFAULT_VISIBLE);
+  }
+}
+
+
+function matchQuery(machine, query) {
+  if (!query) return true;
+  const listLatest = machine.latest || [];
+  const listAll = machine.artifacts || [];
+  const haystack = [
+    machine.series,
+    machine.category,
+    machine.model,
+    machine.group_path,
+    ...listLatest.flatMap((a) => [
+      a.path,
+      a.edk, a.base,
+      a.board_rev, a.version,
+      a.refcode_base, a.release_tag,
+      a.build,
+      a.firmware_type, a.fw_type,
+    ]),
+    ...listAll.flatMap((a) => [
+      a.path,
+      a.edk, a.base,
+      a.board_rev, a.version,
+      a.refcode_base, a.release_tag,
+      a.build,
+      a.firmware_type, a.fw_type,
+    ]),
+  ]
+    .filter(Boolean)
+    .map(normalize)
+    .join(' ');
+  return haystack.includes(query);
+}
+
+function matchTag(machine) {
+  if (!state.tagType || state.tagType === 'all') return true;
+  if (!state.tagValue) return true;
+  return machine[state.tagType] === state.tagValue;
+}
+
+function matchModel(machine) {
+  if (!state.modelValue) return true;
+  return (machine.model || machine.group_path) === state.modelValue;
+}
+
+function createArtifactBox(artifact) {
+  const locale = i18n[state.lang] || i18n.en;
+  const box = document.createElement('div');
+  box.className = 'artifact';
+
+  const label = document.createElement('div');
+  label.className = 'artifact-title';
+  label.textContent = artifactTitleLine(artifact);
+
+  const meta = document.createElement('div');
+  meta.className = 'artifact-meta';
+  artifactMetaLines(artifact).forEach((metaItem) => {
+    const row = document.createElement('div');
+    row.className = 'meta-row';
+    row.textContent = metaItem;
+    meta.appendChild(row);
+  });
+
+  const link = document.createElement('a');
+  link.href = encodeURI(`${RAW_BASE_URL}${artifact.path}`);
+  link.textContent = `${locale.download} ${artifact.path.split('/').pop()}`;
+  link.setAttribute('download', '');
+
+  const sha = document.createElement('div');
+  sha.className = 'sha';
+  sha.textContent = `SHA256: ${artifact.sha256 || 'unknown'}`;
+
+  box.appendChild(label);
+  if (meta.childNodes.length) box.appendChild(meta);
+  box.appendChild(link);
+  box.appendChild(sha);
+
+  return box;
+}
+
+function render() {
+  if (!state.manifest) return;
+  const query = normalize(state.query);
+  const machines = state.manifest.machines || [];
+  const filtered = machines.filter((machine) => matchQuery(machine, query) && matchTag(machine) && matchModel(machine));
+
+  const totalArtifacts = filtered.reduce((count, machine) => {
+    const list = state.showAll ? machine.artifacts : machine.latest;
+    return count + (Array.isArray(list) ? list.length : 0);
+  }, 0);
+
+  const locale = i18n[state.lang] || i18n.en;
+  metaEl.textContent = locale.metaSummary(filtered.length, totalArtifacts);
+
+  cardsEl.innerHTML = '';
+  const sorted = filtered
+    .map((machine) => {
+      const candidates = (machine.latest && machine.latest.length)
+        ? machine.latest
+        : machine.artifacts;
+      const key = bestArtifactKey(candidates);
+      return {
+        machine,
+        hasArtifacts: Array.isArray(candidates) && candidates.length > 0,
+        sortKey: key,
+      };
+    })
+    .sort((a, b) => {
+      if (a.hasArtifacts !== b.hasArtifacts) return a.hasArtifacts ? -1 : 1;
+      if (a.sortKey && b.sortKey) {
+        return compareArtifactKey(b.sortKey, a.sortKey);
+      }
+      const aName = `${a.machine.series || ''}-${a.machine.category || ''}-${a.machine.model || ''}`;
+      const bName = `${b.machine.series || ''}-${b.machine.category || ''}-${b.machine.model || ''}`;
+      return aName.localeCompare(bName);
+    });
+
+  sorted.forEach(({ machine }, index) => {
+      const card = document.createElement('article');
+      card.className = 'card';
+      card.style.setProperty('--i', index);
+
+      const title = document.createElement('h2');
+      title.textContent = machine.model || machine.group_path || 'Unknown model';
+
+      const tags = document.createElement('div');
+      tags.className = 'tags';
+      buildTagList(machine).forEach((tagText) => {
+        const tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.textContent = tagText;
+        tags.appendChild(tag);
+      });
+
+      const group = document.createElement('div');
+      group.className = 'artifact-meta';
+      group.textContent = machine.group_path || '';
+
+      const list = state.showAll ? machine.artifacts : machine.latest;
+      const artifacts = Array.isArray(list) ? list : [];
+
+      card.appendChild(title);
+      if (tags.childNodes.length) card.appendChild(tags);
+      if (group.textContent) card.appendChild(group);
+
+      // Collapsible list inside each model card.
+      const key = machine.group_path || machine.model || String(index);
+      const artifactList = document.createElement('div');
+      artifactList.className = 'artifact-list';
+      updateArtifactList(artifactList, artifacts, key, null);
+      card.appendChild(artifactList);
+
+      if (artifacts.length > DEFAULT_VISIBLE) {
+        const toggle = document.createElement('button');
+        toggle.className = 'artifact-toggle';
+        toggle.type = 'button';
+        toggle.textContent = expandedModels.has(key)
+          ? locale.collapse
+          : locale.expandMore(artifacts.length - DEFAULT_VISIBLE);
+
+        toggle.addEventListener('click', () => {
+          if (expandedModels.has(key)) {
+            expandedModels.delete(key);
+          } else {
+            expandedModels.add(key);
+          }
+          updateArtifactList(artifactList, artifacts, key, toggle);
+          card.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        });
+
+        card.appendChild(toggle);
+      }
+
+      cardsEl.appendChild(card);
+    });
+}
+
+function setMode(showAll) {
+  state.showAll = showAll;
+  latestBtn.classList.toggle('is-active', !showAll);
+  allBtn.classList.toggle('is-active', showAll);
+  render();
+}
+
+searchEl.addEventListener('input', (event) => {
+  state.query = event.target.value;
+  render();
+});
+
+latestBtn.addEventListener('click', () => setMode(false));
+allBtn.addEventListener('click', () => setMode(true));
+zhBtn.addEventListener('click', () => applyLanguage('zh'));
+enBtn.addEventListener('click', () => applyLanguage('en'));
+tagTabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    const type = tab.dataset.tagType || 'all';
+    state.tagType = type;
+    state.tagValue = '';
+    tagTabs.forEach((btn) => btn.classList.toggle('is-active', btn === tab));
+    updateTagOptions();
+    render();
+  });
+});
+
+if (tagSelectEl) {
+  tagSelectEl.addEventListener('change', (event) => {
+    state.tagValue = event.target.value;
+    render();
+  });
+}
+
+if (modelSelectEl) {
+  modelSelectEl.addEventListener('change', (event) => {
+    state.modelValue = event.target.value;
+    render();
+  });
+}
+
+fetch('manifest.json')
+  .then((resp) => {
+    if (!resp.ok) throw new Error(i18n[state.lang]?.loadError || i18n.en.loadError);
+    return resp.json();
+  })
+  .then((data) => {
+    state.manifest = data;
+    updateTagOptions();
+    updateModelOptions();
+    render();
+  })
+  .catch((err) => {
+    metaEl.textContent = err.message;
+  });
+
+applyLanguage(detectLanguage());

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Firmware Downloads</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="bg-orb orb-a"></div>
+    <div class="bg-orb orb-b"></div>
+    <div class="bg-grid"></div>
+
+    <header class="hero">
+      <div class="hero-inner">
+        <p class="eyebrow" id="eyebrow">Loongson Firmware</p>
+        <div class="hero-title-row">
+          <h1 id="heroTitle">Downloads Hub</h1>
+          <a class="repo-link" id="repoLink" href="https://github.com/loongson/firmware" target="_blank" rel="noopener">
+            <span class="repo-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" focusable="false" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+              </svg>
+            </span>
+            <span class="repo-link-text" id="repoLinkText">GitHub Repo</span>
+            <img class="repo-badge" alt="GitHub stars" src="https://img.shields.io/github/stars/loongson/firmware?style=flat&color=ff7a1a&label=stars&logo=github" />
+          </a>
+        </div>
+        <p class="subhead" id="subhead">
+          Latest BIOS and firmware artifacts, grouped by device model. Use search or
+          switch to full history when needed.
+        </p>
+        <div class="hero-actions">
+          <label class="field">
+            <span class="field-label" id="searchLabel">Search</span>
+            <input id="search" type="search" placeholder="Model, series, or path" />
+          </label>
+          <div class="toggle" role="group" aria-label="Artifact scope">
+            <button id="latestBtn" class="toggle-btn is-active" type="button">Latest</button>
+            <button id="allBtn" class="toggle-btn" type="button">All</button>
+          </div>
+          <div class="toggle" role="group" aria-label="Language">
+            <button id="zhBtn" class="toggle-btn" type="button">中文</button>
+            <button id="enBtn" class="toggle-btn" type="button">English</button>
+          </div>
+        </div>
+        <div class="tag-index">
+          <div class="tag-index-block">
+            <span class="field-label" id="tagIndexLabel">Index by</span>
+            <div class="tag-tabs" role="group" aria-label="Tag index">
+              <button class="tag-tab" type="button" data-tag-type="all">All</button>
+              <button class="tag-tab" type="button" data-tag-type="collection">Collection</button>
+              <button class="tag-tab is-active" type="button" data-tag-type="series">Series</button>
+              <button class="tag-tab" type="button" data-tag-type="category">Category</button>
+            </div>
+          </div>
+          <label class="tag-select model-select">
+            <span class="field-label" id="tagSelectLabel">Tags</span>
+            <select id="tagSelect"></select>
+          </label>
+          <label class="tag-select">
+            <span class="field-label" id="modelSelectLabel">Models</span>
+            <select id="modelSelect"></select>
+          </label>
+        </div>
+        <div class="meta" id="meta">Loading manifest...</div>
+      </div>
+    </header>
+
+    <main>
+      <section class="cards" id="cards"></section>
+    </main>
+
+    <footer class="footer">
+      <p id="footerText">Generated from <code>manifest.json</code> and <code>SHA256SUMS.txt</code>.</p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,403 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@400;600;700&display=swap');
+
+:root {
+  color-scheme: light;
+  --bg: #f7f1ea;
+  --bg-deep: #efe6da;
+  --ink: #1f1b16;
+  --muted: #5c5147;
+  --accent: #ff7a1a;
+  --accent-dark: #cc5b0b;
+  --card: #ffffff;
+  --stroke: rgba(31, 27, 22, 0.12);
+  --shadow: 0 20px 60px rgba(31, 27, 22, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Space Grotesk', 'Segoe UI', sans-serif;
+  color: var(--ink);
+  background: radial-gradient(circle at top, #fff7ef 0%, #f7f1ea 55%, #efe6da 100%);
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.bg-orb {
+  position: absolute;
+  width: 460px;
+  height: 460px;
+  border-radius: 50%;
+  filter: blur(40px);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.orb-a {
+  background: #ffddb8;
+  top: -140px;
+  left: -120px;
+}
+
+.orb-b {
+  background: #ffd2c2;
+  bottom: -200px;
+  right: -120px;
+}
+
+.bg-grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(31, 27, 22, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(31, 27, 22, 0.05) 1px, transparent 1px);
+  background-size: 60px 60px;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.hero {
+  padding: 72px 7vw 40px;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-inner {
+  max-width: 1360px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.3em;
+  color: var(--muted);
+  margin: 0 0 10px;
+}
+
+h1 {
+  margin: 0 0 12px;
+  font-size: clamp(36px, 6vw, 64px);
+  line-height: 1;
+}
+
+.hero-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.hero-title-row h1 {
+  margin-bottom: 0;
+}
+
+.subhead {
+  margin: 0 0 32px;
+  color: var(--muted);
+  max-width: 700px;
+  font-size: 18px;
+}
+
+.repo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+  color: var(--accent-dark);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.repo-link:hover {
+  text-decoration: underline;
+}
+
+.repo-link-icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.repo-link-text {
+  white-space: nowrap;
+}
+
+.repo-badge {
+  height: 20px;
+  border-radius: 999px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: end;
+}
+
+.tag-index {
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: end;
+}
+
+.tag-index-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tag-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-tab {
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-family: inherit;
+  font-size: 13px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.tag-tab.is-active {
+  background: var(--ink);
+  color: #fff;
+}
+
+.tag-select {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.model-select {
+  margin-left: auto;
+}
+
+.tag-select select {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--ink);
+}
+
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 320px;
+}
+
+.field-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+input[type="search"] {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.8);
+  font-size: 16px;
+  font-family: inherit;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.toggle {
+  display: flex;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 6px;
+}
+
+.toggle-btn {
+  border: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.toggle-btn.is-active {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(255, 122, 26, 0.3);
+}
+
+.meta {
+  margin-top: 18px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+  padding: 0 7vw 60px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 22px;
+  max-width: 1360px;
+  margin: 0 auto;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 20px;
+  padding: 20px 20px 18px;
+  border: 1px solid var(--stroke);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: rise 0.6s ease forwards;
+  animation-delay: calc(var(--i) * 40ms);
+}
+
+@keyframes rise {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.tag {
+  background: var(--bg-deep);
+  padding: 6px 10px;
+  border-radius: 999px;
+}
+
+.artifact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(31, 27, 22, 0.08);
+  background: #fff9f4;
+}
+
+.artifact-title {
+  font-weight: 600;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.artifact-meta {
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.meta-row {
+  line-height: 1.35;
+}
+
+.artifact a {
+  color: var(--accent-dark);
+  text-decoration: none;
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.artifact a:hover {
+  text-decoration: underline;
+}
+
+.sha {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.footer {
+  text-align: center;
+  padding: 30px 16px 50px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 56px 6vw 32px;
+  }
+
+  .hero-actions {
+    align-items: stretch;
+  }
+
+  .toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+
+.artifact-toggle {
+  margin-top: 10px;
+  align-self: flex-start;
+  border: 1px solid var(--stroke);
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.artifact-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(31, 27, 22, 0.10);
+}
+
+.artifact-toggle:active {
+  transform: translateY(0px);
+}


### PR DESCRIPTION
- Adds a GitHub Pages workflow to build and publish the firmware downloads site automatically.
- Introduces a static downloads UI (web/index.html, web/app.js, web/style.css) with search, filters, and expandable artifact lists.
- Adds scripts/generate-manifest.py to scan firmware artifacts and generate manifest.json consumed by the UI.
- Updates README.md and README_CN.md with the Pages URL.

See: https://loongson.github.io/Firmware/